### PR TITLE
Modernize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
-FROM java:8-jre
+FROM openjdk:8-jre-alpine
+
+ENV FLYWAY_VERSION=5.0.7
 
 # Install psql to allow for cleaner database initialization scripts.
-RUN apt-get update && apt-get install -y \
+RUN apk update && apk add --no-cache \
+    bash \
+    curl \
     postgresql-client \
-    && rm -rf /var/lib/apt/lists/*
-
-ENV FLYWAY_VERSION=4.0
-
-RUN mkdir -p /usr/local/flyway && \
+    tar && \
+    mkdir -p /usr/local/flyway && \
     curl -SLO http://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/$FLYWAY_VERSION/flyway-commandline-$FLYWAY_VERSION.tar.gz && \
-    tar -xzf "flyway-commandline-$FLYWAY_VERSION.tar.gz" -C /usr/local/flyway --strip-components=1
+    tar -xzf "flyway-commandline-$FLYWAY_VERSION.tar.gz" -C /usr/local/flyway --strip-components=1 && \
+    apk del curl tar && \
+    rm "flyway-commandline-$FLYWAY_VERSION.tar.gz"
 
 ENTRYPOINT ["/usr/local/flyway/flyway"]


### PR DESCRIPTION
The java docker image has been deprecated in favor of the openjdk one,
and upgrad to flyway 5.0.7.